### PR TITLE
Replace ffi with fiddle

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 

--- a/capsicum.gemspec
+++ b/capsicum.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.5"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.2"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/capsicum.gemspec
+++ b/capsicum.gemspec
@@ -32,6 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-
-  spec.add_runtime_dependency "ffi", "~> 1.9"
 end

--- a/capsicum.gemspec
+++ b/capsicum.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/capsicum.rb
+++ b/lib/capsicum.rb
@@ -1,19 +1,35 @@
 require "capsicum/version"
-require 'ffi'
+require "fiddle"
 
 module Capsicum
-  class IntPtr < FFI::Struct
-    layout :value, :int
-  end
-
+  # @api private
   module LibC
-    extend FFI::Library
-    ffi_lib [FFI::CURRENT_PROCESS, 'c']
+    module_function
 
-    attach_variable :errno, :int
+    # Provides a Ruby interface for cap_enter(2)
+    # @return [Integer]
+    def cap_enter
+      Fiddle::Function.new(
+        libc["cap_enter"],
+        [],
+        Fiddle::Types::INT
+      ).call
+    end
 
-    attach_function :cap_enter, [], :int
-    attach_function :cap_getmode, [IntPtr], :int
+    # Provides a Ruby interface for cap_getmode(2)
+    # @param [Fiddle::Pointer] uintp
+    # @return [Integer]
+    def cap_getmode(uintp)
+      Fiddle::Function.new(
+        libc["cap_getmode"],
+        [Fiddle::Types::INTPTR_T],
+        Fiddle::Types::INT
+      ).call(uintp)
+    end
+
+    def libc
+      @libc ||= Fiddle.dlopen Dir["/lib/libc.*"].first
+    end
   end
 
   # Check if we're in capability mode.
@@ -23,14 +39,16 @@ module Capsicum
   # @return [Boolean] true if we've entered capability mode
   # @raise [Errno::ENOTCAPABLE] - Capsicum not enabled.
   def sandboxed?
-    ptr = IntPtr.new
-    ret = LibC.cap_getmode(ptr)
+    uintp = Fiddle::Pointer.malloc(Fiddle::SIZEOF_UINT)
+    ret = LibC.cap_getmode(uintp)
 
     if ret == 0
-      ptr[:value] == 1
+      uintp[0, Fiddle::SIZEOF_UINT].unpack('i') == [1]
     else
-      raise SystemCallError.new("cap_getmode", LibC.errno)
+      raise SystemCallError.new("cap_getmode", Fiddle.last_error)
     end
+  ensure
+    uintp.call_free
   end
 
   # Enter capability sandbox mode.
@@ -45,7 +63,7 @@ module Capsicum
     if ret == 0
       return true
     else
-      raise SystemCallError.new("cap_enter", LibC.errno)
+      raise SystemCallError.new("cap_enter", Fiddle.last_error)
     end
   end
 

--- a/test/capsicum_test.rb
+++ b/test/capsicum_test.rb
@@ -39,7 +39,7 @@ class CapsicumTest < Minitest::Test
       File.new("/dev/null")
     end
 
-    assert_raises(Errno::ECAPMODE) do
+    assert_raises(Errno::ENOENT) do
       puts `ls`
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'capsicum'
-
-require 'minitest/autorun'
+require "bundler/setup"
+require "capsicum"
+require "minitest/autorun"


### PR DESCRIPTION
The fiddle library is part of Ruby's standard library, 
and works out of the box for me on HardenedBSD - 
where as the ffi gem raises an error on require